### PR TITLE
Chore ESLint 및 Prettier 설정 구성 및 테스트 완료 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "semi": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  // 💡 포맷 및 린트 자동 실행
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.fixAll.eslint": true
+  },
+
+  // 💡 ESLint가 VSCode에서 경고/에러 표시하도록 활성화
+  "eslint.enable": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+
+  // 💡 Prettier 포맷터를 기본으로 사용
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  // 💡 저장 시 자동 포맷 실행
+  "editor.formatOnSave": true,
+
+  // 💡 ESLint 자동 수정 적용 (var → const 등)
+  "eslint.codeActionsOnSave.rules": null
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,67 @@
+// 플러그인 import
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
+import unusedImportsPlugin from "eslint-plugin-unused-imports";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import tailwindPlugin from "eslint-plugin-tailwindcss";
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
-const eslintConfig = defineConfig([
+export default defineConfig([
   ...nextVitals,
   ...nextTs,
-  // Override default ignores of eslint-config-next.
-  globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
+  {
+    ignores: ["node_modules/", ".next/", "out/", "dist/", "build/", "coverage/"],
+    languageOptions: {
+      parser: tsParser, // ✅ 문자열이 아니라 import한 parser 객체
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      import: importPlugin,
+      "unused-imports": unusedImportsPlugin,
+      "react-hooks": reactHooksPlugin,
+      tailwindcss: tailwindPlugin,
+    },
+    settings: {
+      "import/resolver": {
+        typescript: { project: ["./tsconfig.json"] },
+        node: { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+      },
+      tailwindcss: {
+        callees: ["cn"],
+      },
+    },
+    rules: {
+      "unused-imports/no-unused-imports": "error",
+      "unused-imports/no-unused-vars": [
+        "warn",
+        { vars: "all", varsIgnorePattern: "^_", args: "after-used", argsIgnorePattern: "^_" },
+      ],
+      "import/order": [
+        "warn",
+        {
+          groups: [
+            "builtin",
+            "external",
+            "internal",
+            ["parent", "sibling", "index"],
+            "object",
+            "type",
+          ],
+          pathGroups: [
+            { pattern: "react", group: "external", position: "before" },
+            { pattern: "next/**", group: "external", position: "before" },
+            { pattern: "@/**", group: "internal", position: "after" },
+          ],
+          pathGroupsExcludedImportTypes: ["react"],
+          "newlines-between": "always",
+          alphabetize: { order: "asc", caseInsensitive: true },
+        },
+      ],
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+    },
+  },
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);
-
-export default eslintConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+
+import type { Metadata } from "next";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,11 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
# PR 제목
[Chore] ESLint 및 Prettier 설정 구성 및 테스트 완료 
> Type: Chore

## 개요
- ESLint Flat Config(`eslint.config.mjs`) 방식으로 설정을 구성했습니다.  
- Prettier 규칙을 `.prettierrc` 파일로 추가하고 VSCode 자동 포맷 환경을 테스트했습니다.  
- 주요 규칙이 정상 작동함을 확인했습니다.

## 관련 이슈
- Close #5 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `chore/5-eslint-prettier-config`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- `eslint.config.mjs` 구성 (Flat Config 방식)
- `.prettierrc` 추가
- ESLint, Prettier, VSCode 통합 테스트 완료
- `test.tsx`로 규칙 작동 확인 ( test 파일 삭제 완료 )

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- `npm run lint` 실행 시 규칙 경고 정상 표시
- VSCode 내 자동 포맷 및 ESLint 경고 정상 동작 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)