### PR TITLE
[Feat] 지도 임시 레이아웃 및 Kakao 지도 기본 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "16.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-kakao-maps-sdk": "^1.2.0",
         "react-redux": "^9.2.0"
       },
       "devDependencies": {
@@ -6613,6 +6614,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8238,6 +8245,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.0.tgz",
+      "integrity": "sha512-ptyHhtSbvyza+9IAf6TXjE4ZhwwLbXR6avgNM2ju5xed2+fDwJ+gJDFSqhfsKbvFn9K9+3I+dY3JrqruwsGNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next": "16.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-kakao-maps-sdk": "^1.2.0",
     "react-redux": "^9.2.0"
   },
   "devDependencies": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,9 +8,21 @@ body {
 }
 
 .container-layout {
-  @apply max-w-layout mx-auto px-4;
+  @apply mx-auto max-w-layout px-4;
 }
 
 .container-header {
-  @apply max-w-header mx-auto px-4;
+  @apply mx-auto max-w-header px-4;
+}
+
+.flex-center {
+  @apply flex items-center justify-center;
+}
+
+.flex-between {
+  @apply flex items-center justify-between;
+}
+
+.flex-col-between {
+  @apply flex flex-col justify-between;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
           </header>
         </nav>
 
-        <main className="mx-auto w-full max-w-layout pb-20">{children}</main>
+        <main className="mx-auto w-full max-w-layout py-20">{children}</main>
       </body>
     </html>
   );

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,9 @@
+import MapLayout from "src/features/map/components/MapLayout";
+
+export default function MapPage() {
+  return (
+    <div className="flex-center relative">
+      <MapLayout />
+    </div>
+  );
+}

--- a/src/features/map/components/MapAside.tsx
+++ b/src/features/map/components/MapAside.tsx
@@ -2,7 +2,7 @@
 
 export default function MapAside() {
   return (
-    <aside className="flex-col-between border-1 absolute left-[20px] top-1/2 h-full max-h-[calc(100%-40px)] w-full max-w-[450px] -translate-y-1/2 transform rounded-2xl bg-white">
+    <aside className="flex-col-between absolute left-[20px] top-1/2 z-[9999] h-full max-h-[calc(100%-40px)] w-full max-w-[450px] -translate-y-1/2 transform rounded-2xl border-4 border-line-light bg-white">
       <div className="flex h-full flex-col overflow-y-auto p-4">
         {/* 위치 찾기 */}
         <div>

--- a/src/features/map/components/MapAside.tsx
+++ b/src/features/map/components/MapAside.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+export default function MapAside() {
+  return (
+    <aside className="flex-col-between border-1 absolute left-[20px] top-1/2 h-full max-h-[calc(100%-40px)] w-full max-w-[450px] -translate-y-1/2 transform rounded-2xl bg-white">
+      <div className="flex h-full flex-col overflow-y-auto p-4">
+        {/* 위치 찾기 */}
+        <div>
+          <div className="mb-2 flex items-center justify-between font-semibold text-gray-900">
+            <h2 className="text-xl">위치 찾기</h2>
+            <button className="text-base">현 위치</button>
+          </div>
+
+          <p className="mb-1 text-sm text-gray-400">시도/시군구 까지 입력이 필요합니다.</p>
+          <div className="flex-between mb-4 gap-2">
+            <select name="map1" id="" className="h-11 flex-1 rounded bg-gray-300 px-2">
+              <option value="">시도</option>
+            </select>
+            <select name="map2" id="" className="h-11 flex-1 rounded bg-gray-300 px-2">
+              <option value="">시군구</option>
+            </select>
+            <select name="map3" id="" className="h-11 flex-1 rounded bg-gray-300 px-2">
+              <option value="">읍면동</option>
+            </select>
+          </div>
+
+          {/* 카테고리 필터 */}
+          <div className="mb-4 flex flex-wrap gap-2">
+            {["병원", "카페", "미용실"].map((label) => (
+              <button
+                key={label}
+                className="h-11 rounded bg-gray-300 px-3 py-1 font-medium hover:bg-line-light hover:text-gray-900"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 매장 리스트 */}
+        <div className="flex flex-col gap-3">
+          <div className="rounded-xl bg-thumbnail-200 p-4 shadow-sm">
+            <div className="flex-between mb-2">
+              <p className="font-semibold text-gray-900">가게명</p>
+              <button className="font-semibold text-gray-600">🩶</button>
+            </div>
+            <div className="flex-between">
+              <p className="text-sm text-gray-600">업종</p>
+              <button className="font-semibold text-gray-600">자세히</button>
+            </div>
+          </div>
+          <div className="rounded-xl bg-thumbnail-200 p-4 shadow-sm">
+            <div className="flex-between mb-2">
+              <p className="font-semibold text-gray-900">가게명</p>
+              <button className="font-semibold text-gray-600">❤️</button>
+            </div>
+            <div className="flex-col-between mt-5 gap-1">
+              <p className="text-sm text-gray-500">전화번호 : 000-0000-0000</p>
+              <p className="text-sm text-gray-500">주소 : 서울특별시 00로 00길 00-00</p>
+              <div className="flex-between mt-1">
+                <p className="text-sm text-gray-400">업종</p>
+                <button className="font-semibold text-gray-600">접기</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/map/components/MapContainer.tsx
+++ b/src/features/map/components/MapContainer.tsx
@@ -1,9 +1,20 @@
 "use client";
 
+import { Map } from "react-kakao-maps-sdk";
+
+import useKakaoLoader from "../hooks/UseKakaoLoader";
+
 export default function MapContainer() {
+  // Kakao SDK 로드
+  useKakaoLoader();
+
   return (
-    <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200 text-gray-400">
-      지도 영역 (API 연동 예정)
+    <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200">
+      <Map
+        center={{ lat: 37.55319, lng: 126.9726 }}
+        level={3}
+        style={{ width: "100%", height: "100%" }}
+      />
     </div>
   );
 }

--- a/src/features/map/components/MapContainer.tsx
+++ b/src/features/map/components/MapContainer.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function MapContainer() {
+  return (
+    <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200 text-gray-400">
+      지도 영역 (API 연동 예정)
+    </div>
+  );
+}

--- a/src/features/map/components/MapLayout.tsx
+++ b/src/features/map/components/MapLayout.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import MapAside from "./MapAside";
+import MapContainer from "./MapContainer";
+
+export default function MapLayout() {
+  return (
+    <section className="flex h-dvh max-h-[780px] w-full overflow-hidden rounded-2xl">
+      <MapContainer />
+      <MapAside />
+    </section>
+  );
+}

--- a/src/features/map/hooks/UseKakaoLoader.ts
+++ b/src/features/map/hooks/UseKakaoLoader.ts
@@ -1,0 +1,8 @@
+import { useKakaoLoader as useKakaoLoaderOrigin } from "react-kakao-maps-sdk";
+
+export default function useKakaoLoader() {
+  useKakaoLoaderOrigin({
+    appkey: process.env.NEXT_PUBLIC_KAKAO_MAP_KEY!,
+    libraries: ["clusterer", "drawing", "services"],
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "baseUrl": ".",
     "paths": {
       "@/": ["src/"]
-    }
+    },
+    "types": ["kakao.maps.d.ts"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
# PR 제목
[Feat] 지도 임시 레이아웃 및 Kakao 지도 기본 연동
> Type: Feat

## 개요
- 지도 페이지의 기본 uI 작업 완료
- 지도 api 연동 완료
- 위 내용은 임시 구현이며 추후 컴포넌트 분리, api 기능 확장 진행 예정

## 관련 이슈
- Close #10 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/10-map-layout-api`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- features/map/components/MapContainer.tsx
Kakao Maps SDK 연동 (react-kakao-maps-sdk + useKakaoLoader)
지도 기본 중심좌표(서울) 표시

- features/map/components/MapLayout.tsx
좌측 사이드 영역과 지도 영역 분리

- .env.local (git 미업로드)
NEXT_PUBLIC_KAKAO_MAP_KEY 환경변수 추가
카카오 개발자 콘솔 웹 플랫폼 URL(http://localhost:3000) 등록


## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부
<img width="1336" height="732" alt="image" src="https://github.com/user-attachments/assets/38d6d1b8-847c-4b50-8bf3-5b6bfd83ab14" />


## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- npm run dev 실행 시 http://localhost:3000 에서 지도 정상 표시됨
- 환경변수(NEXT_PUBLIC_KAKAO_MAP_KEY) 정상 인식
- react-kakao-maps-sdk 정상 동작

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)