### PR TITLE
[Chore] Redux Toolkit Provider 전역 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import { Geist, Geist_Mono } from "next/font/google";
 
 import type { Metadata } from "next";
+
 import "./globals.css";
+import ReduxProvider from "src/store/ReduxProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,13 +28,15 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="bg-background text-gray-100">
-        <nav className="w-full border-b border-line-light">
-          <header className="mx-auto flex h-[60px] w-full max-w-header items-center px-4">
-            <h1 className="text-lg font-bold text-gray-900">WithPet</h1>
+        <ReduxProvider>
+          <header className="w-full border-b border-line-light">
+            <nav className="mx-auto flex h-[60px] w-full max-w-header items-center px-4">
+              <h1 className="text-lg font-bold text-gray-900">WithPet</h1>
+            </nav>
           </header>
-        </nav>
 
-        <main className="mx-auto w-full max-w-layout py-20">{children}</main>
+          <main className="mx-auto w-full max-w-layout py-20">{children}</main>
+        </ReduxProvider>
       </body>
     </html>
   );

--- a/src/store/ReduxProvider.tsx
+++ b/src/store/ReduxProvider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { Provider } from "react-redux";
+
+import { store } from "./index";
+
+export default function ReduxProvider({ children }: { children: React.ReactNode }) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,10 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+export const store = configureStore({
+  reducer: {
+    // ex: exSlice,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/store/test.tsx
+++ b/src/store/test.tsx
@@ -1,3 +1,0 @@
-export default function Test() {
-  return <div>로그인 페이지</div>;
-}


### PR DESCRIPTION
# PR 제목
[Chore] Redux Toolkit Provider 전역 설정
> Type: Chore

## 개요
- 전역 상태 관리를 위한 Redux Toolkit 환경을 초기화
- store 및 Provider 컴포넌트를 설정하여, 추후 모든 페이지에서 전역 상태 접근이 가능하도록 구성

## 관련 이슈
- Close #19 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `chore/19-redux-provider  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- store/index.ts 초기화 설정
- "use client" 선언 후 Redux <Provider> 감싸는 컴포넌트 생성


## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)