### PR TITLE
[Feat] MSW 기본 구조 및 지도 관련 Mock API 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,10 @@
     "prettier-plugin-tailwindcss": "^0.7.1",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.11.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 
 import "./globals.css";
 import ReduxProvider from "src/store/ReduxProvider";
+import MSWProvider from "src/providers/MSWProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,13 +30,14 @@ export default function RootLayout({
     <html lang="ko">
       <body className="bg-background text-gray-100">
         <ReduxProvider>
-          <header className="w-full border-b border-line-light">
-            <nav className="mx-auto flex h-[60px] w-full max-w-header items-center px-4">
-              <h1 className="text-lg font-bold text-gray-900">WithPet</h1>
-            </nav>
-          </header>
-
-          <main className="mx-auto w-full max-w-layout py-20">{children}</main>
+          <MSWProvider>
+            <header className="w-full border-b border-line-light">
+              <nav className="mx-auto flex h-[60px] w-full max-w-header items-center px-4">
+                <h1 className="text-lg font-bold text-gray-900">WithPet</h1>
+              </nav>
+            </header>
+            <main className="mx-auto w-full max-w-layout py-20">{children}</main>
+          </MSWProvider>
         </ReduxProvider>
       </body>
     </html>

--- a/src/mocks/browers.ts
+++ b/src/mocks/browers.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from "msw/browser";
+
+import { mapHandlers } from "./handlers/mapHandlers";
+
+export const worker = setupWorker(...mapHandlers);

--- a/src/mocks/data/mapData.ts
+++ b/src/mocks/data/mapData.ts
@@ -1,0 +1,44 @@
+export const provinces = [
+  { id: "11", name: "서울특별시", code: "SEOUL" },
+  { id: "41", name: "경기도", code: "GYEONGGI" },
+  { id: "26", name: "부산광역시", code: "BUSAN" },
+];
+
+export const districts = [
+  { id: "11680", name: "강남구", province_id: "11", code: "GANGNAM" },
+  { id: "11650", name: "서초구", province_id: "11", code: "SEOCHO" },
+  { id: "11110", name: "종로구", province_id: "11", code: "JONGNO" },
+];
+
+export const neighborhoods = [
+  { id: "1168010100", name: "역삼동", district_id: "11680", code: "YEOKSAM" },
+  { id: "1168010200", name: "논현동", district_id: "11680", code: "NONHYEON" },
+  { id: "1168010300", name: "삼성동", district_id: "11680", code: "SAMSUNG" },
+];
+
+export const categories = [
+  { id: "001", name: "동물병원", code: "HOSPITAL" },
+  { id: "002", name: "반려동물미용", code: "BEAUTY" },
+  { id: "003", name: "반려동물호텔", code: "HOTEL" },
+  { id: "004", name: "반려동물카페", code: "CAFE" },
+];
+
+export const stores = [
+  {
+    id: "001",
+    name: "강남 24시 동물병원",
+    category: { id: "001", name: "동물병원" },
+    address: {
+      province: "서울특별시",
+      district: "강남구",
+      neighborhood: "역삼동",
+      detail: "테헤란로 123",
+      full_address: "서울특별시 강남구 역삼동 테헤란로 123",
+    },
+    phone: "02-1234-5678",
+    rating: 4.5,
+    review_count: 328,
+    tags: ["24시간", "주차가능", "야간진료"],
+    distance: null,
+  },
+];

--- a/src/mocks/handlers/mapHandlers.ts
+++ b/src/mocks/handlers/mapHandlers.ts
@@ -1,0 +1,35 @@
+import { http, HttpResponse } from "msw";
+
+import { provinces, districts, neighborhoods, categories, stores } from "../data/mapData";
+
+export const mapHandlers = [
+  http.get("/api/map/provinces", () => HttpResponse.json({ success: true, data: provinces })),
+
+  http.get("/api/map/districts", () => HttpResponse.json({ data: districts })),
+
+  http.get("/api/map/neighborhoods", () => HttpResponse.json({ data: neighborhoods })),
+
+  http.get("/api/map/categories", () => HttpResponse.json({ data: categories })),
+
+  http.get("/api/map/stores", () =>
+    HttpResponse.json({
+      data: {
+        items: stores,
+        filters: {
+          province: "서울특별시",
+          district: "강남구",
+          neighborhood: null,
+          categories: [],
+          keyword: null,
+        },
+      },
+    }),
+  ),
+
+  http.get("/api/map/stores/:id", ({ params }) => {
+    const { id } = params;
+    const store = stores.find((s) => s.id === id);
+    if (!store) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json({ data: store });
+  }),
+];

--- a/src/providers/MSWProvider.tsx
+++ b/src/providers/MSWProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function MSWProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
+      import("src/mocks/browers")
+        .then(({ worker }) => worker.start())
+        .then(() => console.log("[MSW] Mock Service Worker started"))
+        .catch((err) => console.error("[MSW] Failed to start:", err));
+    }
+  }, []);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
# PR 제목
[Feat] MSW 기본 구조 및 지도 관련 Mock API 세팅
> Type: Feat

## 개요
- 백엔드 연동 전, 프론트 개발용 Mock API 환경 구축
- msw 기반으로 지도 관련 API 작성

## 관련 이슈
- Close #21 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/21-msw-setup  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- src/mocks/ 폴더 추가
browser.ts: setupWorker 정의
handlers/mapHandlers.ts: 지도 관련 Mock API 작성
data/mapData.ts: 실제 Mock 데이터 정의
- src/providers/MSWProvider.tsx 생성
- 환경 변수 NEXT_PUBLIC_API_MOCKING=enabled 시 사용가능


## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)