### PR TITLE
Feat: 빈 게시글일 경우 컴포넌트 구현

### DIFF
--- a/src/components/community/EmptyState.tsx
+++ b/src/components/community/EmptyState.tsx
@@ -1,0 +1,8 @@
+export default function EmptyState() {
+  return (
+    <div className="w-wrapper flex h-[820px] flex-col items-center justify-center bg-orange-100">
+      <div className="mb-14 text-xl font-bold text-gray-900">WithPet</div>
+      <div className="text-2xl font-bold text-orange-600">작성한 게시글이 없습니다.</div>
+    </div>
+  );
+}

--- a/src/components/community/shell/CommunityShell.tsx
+++ b/src/components/community/shell/CommunityShell.tsx
@@ -68,6 +68,7 @@ export default function CommunityShell({ category }: { category: CommunityCatego
           .map((el) => (
             <PostItem key={el} title={category} />
           ))}
+        {/* <EmptyState /> 게시글 없거나 검색 결과 없을 경우 props로 활용*/}
       </div>
 
       <div className="my-10">


### PR DESCRIPTION
## 개요
- 빈 게시글일 경우 컴포넌트 구현 (일치하지 않은 검색결과 컴포넌트는 이 컴포넌트로 활용 예정)

## 관련 이슈
- Close #42 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `Feat/42-community-empty-and-no-results-ui`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 빈 게시글일 경우 컴포넌트 생성

## 스크린샷/동영상(선택)
<img width="1366" height="902" alt="스크린샷 2025-11-07 오전 11 42 26" src="https://github.com/user-attachments/assets/d77ed846-ed71-429b-8d28-fa89b779fccb" />
<img width="1366" height="899" alt="스크린샷 2025-11-07 오전 11 42 47" src="https://github.com/user-attachments/assets/8c709d6f-f044-415d-9123-ab4b7a375270" />


## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)