### PR TITLE
[Feat] 지도 검색 구조 개편 및 매장 마커/리스트 연동

### DIFF
--- a/src/features/map/api/mapApi.ts
+++ b/src/features/map/api/mapApi.ts
@@ -10,6 +10,31 @@ import type {
 } from "@/types/mapTypes";
 
 /**
+ * 지도 도메인 전용 API 모듈
+ *
+ * - 사용 흐름은 `shared/api/client.ts → features/map/api/mapApi.ts → 도메인 훅(useLocations/useStoreQuery 등) → 컴포넌트`
+ * - client.ts 에서는 base URL, 공통 헤더만 정의하고 여기서는 실제 엔드포인트만 선언
+ * - 다른 도메인에서도 `features/{domain}/api/{domain}Api.ts` 식으로 두면, 호출 구조가 한눈에 들어옴
+ *
+ * 예시)
+ * ```ts
+ * // 1) 공용 apiClient 가져오기
+ * import { apiClient } from "@/shared/api/client";
+ *
+ * // 2) 도메인 API 파일에서 함수 작성
+ * export const getFoo = () => apiClient("/api/foo");
+ *
+ * // 3) 해당 도메인 훅에서 호출
+ * export function useFoo() {
+ *   return useQuery({ queryKey: ["foo"], queryFn: getFoo });
+ * }
+ *
+ * // 4) 컴포넌트에서 훅 사용
+ * const { data } = useFoo();
+ * ```
+ */
+
+/**
  * LocationParams 객체를 URL 쿼리스트링으로 변환합니다.
  *
  * 예:

--- a/src/features/map/stores/api/useStoreQuery.ts
+++ b/src/features/map/stores/api/useStoreQuery.ts
@@ -6,17 +6,17 @@ import { useQuery } from "@tanstack/react-query";
 import { useDispatch } from "react-redux";
 
 import { getStores } from "@/features/map/api/mapApi";
-import { setStoreMarkers } from "@/shared/store/mapSlice";
+import { setStoreDetails, setStoreMarkers, type StoreDetailInfo } from "@/shared/store/mapSlice";
 import type { StoreFilters, StoreResponse } from "@/types/mapTypes";
 
 import { mapStoresToListItems } from "./storeMapper";
 
-/**
- * 가게 목록을 조회하고, 화면에서 쓰기 좋은 형태로 가공한 뒤 반환합니다.
- *
- * - district 값이 없으면 요청을 보내지 않습니다.
- * - 응답으로 받은 좌표는 Redux `storeMarkers`에 저장해 지도에서도 재사용합니다.
- */
+// @기능
+// - 주어진 지역/카테고리/좌표 필터로 가게 목록을 요청하고 화면에서 쓰기 좋은 형태로 리턴
+// @구현
+// - district 없으면 바로 return해서 불필요한 API 요청 막고
+// - select 옵션으로 응답 데이터를 mapper 한 번만 돌린 다음
+// - useEffect에서 지도 마커랑 상세정보를 Redux에 저장해 MapContainer쪽에서 그대로 씀
 export function useStoreQuery(filters: StoreFilters) {
   const dispatch = useDispatch();
   const enabled = Boolean(filters.district);
@@ -30,16 +30,25 @@ export function useStoreQuery(filters: StoreFilters) {
 
   useEffect(() => {
     if (query.data) {
-      dispatch(
-        setStoreMarkers(
-          query.data.map((store) => ({
-            id: store.id,
-            name: store.name,
-            latitude: store.latitude,
-            longitude: store.longitude,
-          })),
-        ),
-      );
+      const markers = query.data.map((store) => ({
+        id: store.id,
+        name: store.name,
+        latitude: store.latitude,
+        longitude: store.longitude,
+      }));
+
+      const details: StoreDetailInfo[] = query.data.map((store) => ({
+        id: store.id,
+        name: store.name,
+        latitude: store.latitude,
+        longitude: store.longitude,
+        category: store.category,
+        phone: store.phone,
+        address: store.address,
+      }));
+
+      dispatch(setStoreMarkers(markers));
+      dispatch(setStoreDetails(details));
     }
   }, [dispatch, query.data]);
 

--- a/src/features/map/stores/ui/MapStoreList.tsx
+++ b/src/features/map/stores/ui/MapStoreList.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useMemo } from "react";
+
 import { useSelector } from "react-redux";
 
 import { cn } from "@/lib/utils";
 import type { RootState } from "@/shared/store";
 import type { StoreFilters } from "@/types/mapTypes";
 
-import { useStoreQuery } from "../api/useStoreQuery";
 import MapStoreCard from "./MapStoreCard";
+import { useStoreQuery } from "../api/useStoreQuery";
 
 interface MapStoreListProps {
   className?: string;
@@ -27,16 +28,21 @@ export default function MapStoreList({ className }: MapStoreListProps) {
   const selectedCategory = useSelector((state: RootState) => state.map.selectedCategory);
   const center = useSelector((state: RootState) => state.map.center);
 
+  /**
+   * 훅 사용을 위한 요청 조건 객체
+   *
+   * React Query 캐시 키로 쓰이기 때문에, 동일한 지역/카테고리/좌표 조합이면 서버를 다시 안 치고 캐싱된 데이터를 곧바로 씀
+   */
   const filters = useMemo<StoreFilters>(
     () => ({
       province: province || undefined,
       district: district || undefined,
       neighborhood: neighborhood || undefined,
       categoryCodes: selectedCategory ? [selectedCategory] : undefined,
-      latitude: center.lat,
-      longitude: center.lng,
+      latitude: center.latitude,
+      longitude: center.longitude,
     }),
-    [province, district, neighborhood, selectedCategory, center.lat, center.lng],
+    [province, district, neighborhood, selectedCategory, center.latitude, center.longitude],
   );
 
   const { data, isLoading, isError } = useStoreQuery(filters);

--- a/src/features/map/ui/MapContainer.tsx
+++ b/src/features/map/ui/MapContainer.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
-import { Map, MapMarker } from "react-kakao-maps-sdk";
+import { Map, MapMarker, CustomOverlayMap } from "react-kakao-maps-sdk";
 import { useSelector } from "react-redux";
 
+import Button from "@/components/common/button/Button";
 import useKakaoLoader from "@/shared/hooks/useKakaoLoader";
 import type { RootState } from "@/shared/store";
-import type { StoreMarker } from "@/shared/store/mapSlice";
+import type { StoreDetailInfo, StoreMarker } from "@/shared/store/mapSlice";
 
 /**
  * 실제 카카오 지도를 렌더링하는 컨테이너
@@ -20,28 +21,94 @@ export default function MapContainer() {
 
   const center = useSelector((state: RootState) => state.map.center);
   const storeMarkers = useSelector((state: RootState) => state.map.storeMarkers);
-
-  const mockStoreMarkers: StoreMarker[] = useMemo(
+  const storeDetails = useSelector((state: RootState) => state.map.storeDetails);
+  const [activeStoreId, setActiveStoreId] = useState<number | null>(null);
+  // 검색 전 지도 표시용 mock 데이터
+  const mockStoreDetails: StoreDetailInfo[] = useMemo(
     () => [
-      { id: 1, name: "행복동물병원", latitude: 37.4979, longitude: 127.0276 },
-      { id: 2, name: "멍멍카페 강남점", latitude: 37.5502, longitude: 126.9121 },
-      { id: 3, name: "펫살롱 논현", latitude: 37.5112, longitude: 127.0217 },
+      {
+        id: 1,
+        name: "행복동물병원",
+        category: "동물병원",
+        latitude: 37.4979,
+        longitude: 127.0276,
+        phone: "02-1234-5678",
+        address: "서울특별시 강남구 역삼동 123-45",
+      },
+      {
+        id: 2,
+        name: "멍멍카페 강남점",
+        category: "애견카페",
+        latitude: 37.5502,
+        longitude: 126.9121,
+        phone: "02-4321-8765",
+        address: "서울특별시 마포구 합정동 11-2",
+      },
+      {
+        id: 3,
+        name: "펫살롱 논현",
+        category: "애견미용",
+        latitude: 37.5112,
+        longitude: 127.0217,
+        phone: "02-2468-1357",
+        address: "서울특별시 강남구 논현동 45-1",
+      },
     ],
     [],
   );
 
-  const markers = storeMarkers.length > 0 ? storeMarkers : mockStoreMarkers;
+  const details = storeDetails.length > 0 ? storeDetails : mockStoreDetails;
+  const markers: StoreMarker[] =
+    storeMarkers.length > 0
+      ? storeMarkers
+      : mockStoreDetails.map(({ id, name, latitude, longitude }) => ({
+          id,
+          name,
+          latitude,
+          longitude,
+        }));
+
+  const selectedStore = activeStoreId
+    ? (details.find((store) => store.id === activeStoreId) ?? null)
+    : null;
 
   return (
     <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200">
-      <Map center={center} level={3} style={{ width: "100%", height: "100%" }}>
+      <Map
+        center={{ lat: center.latitude, lng: center.longitude }}
+        level={3}
+        style={{ width: "100%", height: "100%" }}
+      >
         {markers.map((marker) => (
           <MapMarker
             key={marker.id}
             position={{ lat: marker.latitude, lng: marker.longitude }}
             title={marker.name}
+            onClick={() => setActiveStoreId(marker.id)}
           />
         ))}
+        {selectedStore && (
+          <CustomOverlayMap
+            position={{ lat: selectedStore.latitude, lng: selectedStore.longitude }}
+            yAnchor={1}
+          >
+            <div className="rounded-xl border border-orange-200 bg-white p-3 text-sm shadow-md">
+              <div className="mb-1 font-semibold text-gray-900">{selectedStore.name}</div>
+              <p className="text-xs text-gray-600">{selectedStore.category}</p>
+              {selectedStore.phone && (
+                <p className="text-xs text-gray-500">{selectedStore.phone}</p>
+              )}
+              {selectedStore.address && (
+                <p className="text-xs text-gray-500">{selectedStore.address}</p>
+              )}
+              <div className="mt-2">
+                <Button status="primary" className="px-3 py-1 text-xs" onClick={() => setActiveStoreId(null)}>
+                  닫기
+                </Button>
+              </div>
+            </div>
+          </CustomOverlayMap>
+        )}
       </Map>
     </div>
   );

--- a/src/features/map/ui/MapContainer.tsx
+++ b/src/features/map/ui/MapContainer.tsx
@@ -1,25 +1,48 @@
 "use client";
 
-import { Map } from "react-kakao-maps-sdk";
+import { useMemo } from "react";
+
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+import { useSelector } from "react-redux";
 
 import useKakaoLoader from "@/shared/hooks/useKakaoLoader";
+import type { RootState } from "@/shared/store";
+import type { StoreMarker } from "@/shared/store/mapSlice";
 
 /**
- * 실제 카카오 지도를 렌더링하는 컨테이너입니다.
+ * 실제 카카오 지도를 렌더링하는 컨테이너
  *
- * - `useKakaoLoader` 훅이 SDK 로딩을 담당합니다.
- * - 중심 좌표나 레벨 값은 나중에 Redux/쿼리 상태와 연동해 갱신할 수 있습니다.
+ * - Redux에 저장된 `storeMarkers`를 읽어서 지도에 마커로 표시
+ * - 아직 조회한 데이터가 없다면, 임시 더미 데이터를 사용해 기본 마커를 노출
  */
 export default function MapContainer() {
   useKakaoLoader();
 
+  const center = useSelector((state: RootState) => state.map.center);
+  const storeMarkers = useSelector((state: RootState) => state.map.storeMarkers);
+
+  const mockStoreMarkers: StoreMarker[] = useMemo(
+    () => [
+      { id: 1, name: "행복동물병원", latitude: 37.4979, longitude: 127.0276 },
+      { id: 2, name: "멍멍카페 강남점", latitude: 37.5502, longitude: 126.9121 },
+      { id: 3, name: "펫살롱 논현", latitude: 37.5112, longitude: 127.0217 },
+    ],
+    [],
+  );
+
+  const markers = storeMarkers.length > 0 ? storeMarkers : mockStoreMarkers;
+
   return (
     <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200">
-      <Map
-        center={{ lat: 37.55319, lng: 126.9726 }}
-        level={3}
-        style={{ width: "100%", height: "100%" }}
-      />
+      <Map center={center} level={3} style={{ width: "100%", height: "100%" }}>
+        {markers.map((marker) => (
+          <MapMarker
+            key={marker.id}
+            position={{ lat: marker.latitude, lng: marker.longitude }}
+            title={marker.name}
+          />
+        ))}
+      </Map>
     </div>
   );
 }

--- a/src/mocks/data/mapData.ts
+++ b/src/mocks/data/mapData.ts
@@ -1,10 +1,4 @@
-import type {
-  District,
-  FilterCategory,
-  Neighborhood,
-  Province,
-  Store,
-} from "@/types/mapTypes";
+import type { District, FilterCategory, Neighborhood, Province, Store } from "@/types/mapTypes";
 
 export const provinces: Province[] = [
   { id: "11", name: "서울특별시", code: "SEOUL" },
@@ -53,8 +47,8 @@ export const storeFixtures: Store[] = [
     tags: ["24시간", "주차가능", "예약필수"],
     distance: 0.8,
     thumbnail_url: "https://cdn.withpet.com/stores/1001/thumb.jpg",
-    latitude: 37.4979,
-    longitude: 127.0276,
+    latitude: 37.5532,
+    longitude: 126.9727,
   },
   {
     id: 2001,
@@ -74,8 +68,8 @@ export const storeFixtures: Store[] = [
     tags: ["포토존", "예약가능"],
     distance: 2.4,
     thumbnail_url: "https://cdn.withpet.com/stores/2001/thumb.jpg",
-    latitude: 37.5502,
-    longitude: 126.9121,
+    latitude: 37.5532,
+    longitude: 126.9724,
   },
   {
     id: 3001,
@@ -95,7 +89,7 @@ export const storeFixtures: Store[] = [
     tags: ["스파", "프리미엄"],
     distance: 1.1,
     thumbnail_url: "https://cdn.withpet.com/stores/3001/thumb.jpg",
-    latitude: 37.5112,
-    longitude: 127.0217,
+    latitude: 37.5532,
+    longitude: 126.9722,
   },
 ];

--- a/src/shared/store/mapSlice.ts
+++ b/src/shared/store/mapSlice.ts
@@ -13,14 +13,21 @@ export interface StoreMarker {
   longitude: number;
 }
 
+export interface StoreDetailInfo extends StoreMarker {
+  category: string;
+  phone?: string;
+  address?: string;
+}
+
 interface MapState {
   selectedCategory: string | null;
   selectedLocation: MapLocationSelection;
   center: {
-    lat: number;
-    lng: number;
+    latitude: number;
+    longitude: number;
   };
   storeMarkers: StoreMarker[];
+  storeDetails: StoreDetailInfo[];
 }
 
 const initialState: MapState = {
@@ -31,10 +38,11 @@ const initialState: MapState = {
     neighborhood: "",
   },
   center: {
-    lat: 37.55319,
-    lng: 126.9726,
+    latitude: 37.55319,
+    longitude: 126.9726,
   },
   storeMarkers: [],
+  storeDetails: [],
 };
 
 /**
@@ -56,9 +64,17 @@ const mapSlice = createSlice({
     setStoreMarkers(state, action: PayloadAction<StoreMarker[]>) {
       state.storeMarkers = action.payload;
     },
+    setStoreDetails(state, action: PayloadAction<StoreDetailInfo[]>) {
+      state.storeDetails = action.payload;
+    },
   },
 });
 
-export const { setCenter, setSelectedCategory, setSelectedLocation, setStoreMarkers } =
-  mapSlice.actions;
+export const {
+  setCenter,
+  setSelectedCategory,
+  setSelectedLocation,
+  setStoreMarkers,
+  setStoreDetails,
+} = mapSlice.actions;
 export default mapSlice.reducer;

--- a/src/shared/store/mapSlice.ts
+++ b/src/shared/store/mapSlice.ts
@@ -1,12 +1,12 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
-interface MapLocationSelection {
+export interface MapLocationSelection {
   province: string;
   district: string;
   neighborhood: string;
 }
 
-interface StoreMarker {
+export interface StoreMarker {
   id: number;
   name: string;
   latitude: number;
@@ -38,7 +38,7 @@ const initialState: MapState = {
 };
 
 /**
- * 지도 화면에서 필요한 공통 상태를 관리하는 슬라이스입니다.
+ * 지도 화면에서 필요한 공통 상태를 관리하는 슬라이스
  */
 const mapSlice = createSlice({
   name: "map",
@@ -59,5 +59,6 @@ const mapSlice = createSlice({
   },
 });
 
-export const { setCenter, setSelectedCategory, setSelectedLocation, setStoreMarkers } = mapSlice.actions;
+export const { setCenter, setSelectedCategory, setSelectedLocation, setStoreMarkers } =
+  mapSlice.actions;
 export default mapSlice.reducer;


### PR DESCRIPTION
# PR 제목
[Feat] 지도 검색 구조 개편 및 매장 마커/리스트 연동
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 카카오 지도 마커 + 상세 오버레이 추가
- API → 훅 → UI 흐름 주석을 보강

## 관련 이슈
- Close #61 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/61-kakao-map-custom`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 주요 변경점(화면/로직/폴더 구조)
- 의존성 추가/삭제(있다면)
- 환경 설정 변경 내용(있다면)

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)