### PR TITLE
[Feat] 지도 컴포넌트에서 사용자 위치 처리 기능 구현

### DIFF
--- a/src/features/map/search/ui/MapHeaderGroup.tsx
+++ b/src/features/map/search/ui/MapHeaderGroup.tsx
@@ -1,9 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import type { AppDispatch, RootState } from "@/shared/store";
+import { setCenter, setUserLocation } from "@/shared/store/mapSlice";
+
+const USER_LOCATION_STORAGE_KEY = "withpet:userLocation";
+
+/**
+ * 지도 검색 영역 상단 헤더 + 현 위치 찾기 버튼
+ */
 export default function MapHeaderGroup() {
+  const dispatch = useDispatch<AppDispatch>();
+  const userLocation = useSelector((state: RootState) => state.map.userLocation);
+  const [isLocating, setIsLocating] = useState(false);
+
+  // 저장해 둔 위치 정보가 있으면 초기 렌더 시 바로 center/userLocation에 반영해서
+  // 사용자가 새로고침해도 “현 위치” 버튼 누르자마자 빠르게 되돌아갈 수 있게 함
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const saved = localStorage.getItem(USER_LOCATION_STORAGE_KEY);
+      if (!saved) return;
+      const parsed = JSON.parse(saved) as { latitude: number; longitude: number };
+      dispatch(setUserLocation(parsed));
+      dispatch(setCenter(parsed));
+    } catch (error) {
+      console.warn("사용자 위치 정보를 불러오지 못했습니다.", error);
+    }
+  }, [dispatch]);
+
+  // 현 위치 버튼 로직
+  // 1. 이전에 위치를 저장해 둔 경우 → 즉시 center 갱신 (빠른 UX)
+  // 2. 위치가 없다면 geolocation 호출 → 성공 시 Redux + localStorage에 저장
+  // 3. 지오로케이션이 오래 걸리면 timeout으로 사용자에게 실패 안내
+  const handleCurrentLocation = () => {
+    if (userLocation) {
+      dispatch(setCenter(userLocation));
+      return;
+    }
+
+    if (!navigator.geolocation) {
+      alert("브라우저에서 위치 정보를 지원하지 않습니다.");
+      return;
+    }
+
+    setIsLocating(true);
+    let timeoutId: number | null = window.setTimeout(() => {
+      alert("현 위치를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+      setIsLocating(false);
+    }, 3000);
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        const payload = { latitude: coords.latitude, longitude: coords.longitude };
+        dispatch(setCenter(payload)); // 1,2. 위치 저장 후 지도 리렌더
+        dispatch(setUserLocation(payload));
+        if (typeof window !== "undefined") {
+          localStorage.setItem(USER_LOCATION_STORAGE_KEY, JSON.stringify(payload));
+        }
+        setIsLocating(false);
+      },
+      () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        alert("현 위치를 불러오지 못했습니다.");
+        setIsLocating(false);
+      },
+    );
+  };
+
   return (
     <>
       <div className="mb-2 flex items-center justify-between font-semibold text-gray-900">
         <h2 className="text-xl">위치 찾기</h2>
-        <button className="text-base">현 위치</button>
+        <button
+          type="button"
+          className="text-primary-500 text-base disabled:text-gray-400"
+          onClick={handleCurrentLocation}
+          disabled={isLocating}
+        >
+          {isLocating ? "현 위치 찾는 중..." : "현 위치"}
+        </button>
       </div>
       <p className="mb-1 text-sm text-gray-400">시도/시군구 까지 입력이 필요합니다.</p>
     </>

--- a/src/features/map/ui/MapContainer.tsx
+++ b/src/features/map/ui/MapContainer.tsx
@@ -92,7 +92,7 @@ export default function MapContainer() {
             position={{ lat: selectedStore.latitude, lng: selectedStore.longitude }}
             yAnchor={1}
           >
-            <div className="rounded-xl border border-orange-200 bg-white p-3 text-sm shadow-md">
+            <div className="rounded-xl border-2 border-orange-200 bg-white p-3 text-sm shadow-md">
               <div className="mb-1 font-semibold text-gray-900">{selectedStore.name}</div>
               <p className="text-xs text-gray-600">{selectedStore.category}</p>
               {selectedStore.phone && (
@@ -102,7 +102,11 @@ export default function MapContainer() {
                 <p className="text-xs text-gray-500">{selectedStore.address}</p>
               )}
               <div className="mt-2">
-                <Button status="primary" className="px-3 py-1 text-xs" onClick={() => setActiveStoreId(null)}>
+                <Button
+                  status="primary"
+                  className="w-full rounded-[4px] px-3 py-1 text-xs"
+                  onClick={() => setActiveStoreId(null)}
+                >
                   닫기
                 </Button>
               </div>

--- a/src/features/map/ui/MapContainer.tsx
+++ b/src/features/map/ui/MapContainer.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Map, MapMarker, CustomOverlayMap } from "react-kakao-maps-sdk";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import Button from "@/components/common/button/Button";
 import useKakaoLoader from "@/shared/hooks/useKakaoLoader";
-import type { RootState } from "@/shared/store";
+import type { AppDispatch, RootState } from "@/shared/store";
+import { setCenter } from "@/shared/store/mapSlice";
 import type { StoreDetailInfo, StoreMarker } from "@/shared/store/mapSlice";
 
 /**
@@ -19,6 +20,8 @@ import type { StoreDetailInfo, StoreMarker } from "@/shared/store/mapSlice";
 export default function MapContainer() {
   useKakaoLoader();
 
+  const dispatch = useDispatch<AppDispatch>();
+  const mapRef = useRef<kakao.maps.Map | null>(null);
   const center = useSelector((state: RootState) => state.map.center);
   const storeMarkers = useSelector((state: RootState) => state.map.storeMarkers);
   const storeDetails = useSelector((state: RootState) => state.map.storeDetails);
@@ -72,12 +75,30 @@ export default function MapContainer() {
     ? (details.find((store) => store.id === activeStoreId) ?? null)
     : null;
 
+  useEffect(() => {
+    if (mapRef.current) {
+      mapRef.current.setCenter(new kakao.maps.LatLng(center.latitude, center.longitude));
+    }
+  }, [center.latitude, center.longitude]);
+
+  const handleCenterChanged = (mapInstance: kakao.maps.Map) => {
+    const latLng = mapInstance.getCenter();
+    dispatch(
+      setCenter({
+        latitude: latLng.getLat(),
+        longitude: latLng.getLng(),
+      }),
+    );
+  };
+
   return (
     <div className="relative flex h-full w-full flex-1 items-center justify-center bg-thumbnail-200">
       <Map
+        ref={mapRef}
         center={{ lat: center.latitude, lng: center.longitude }}
         level={3}
         style={{ width: "100%", height: "100%" }}
+        onCenterChanged={handleCenterChanged}
       >
         {markers.map((marker) => (
           <MapMarker

--- a/src/shared/store/mapSlice.ts
+++ b/src/shared/store/mapSlice.ts
@@ -28,6 +28,10 @@ interface MapState {
   };
   storeMarkers: StoreMarker[];
   storeDetails: StoreDetailInfo[];
+  userLocation: {
+    latitude: number;
+    longitude: number;
+  } | null;
 }
 
 const initialState: MapState = {
@@ -43,6 +47,7 @@ const initialState: MapState = {
   },
   storeMarkers: [],
   storeDetails: [],
+  userLocation: null,
 };
 
 /**
@@ -67,6 +72,9 @@ const mapSlice = createSlice({
     setStoreDetails(state, action: PayloadAction<StoreDetailInfo[]>) {
       state.storeDetails = action.payload;
     },
+    setUserLocation(state, action: PayloadAction<{ latitude: number; longitude: number }>) {
+      state.userLocation = action.payload;
+    },
   },
 });
 
@@ -76,5 +84,6 @@ export const {
   setSelectedLocation,
   setStoreMarkers,
   setStoreDetails,
+  setUserLocation,
 } = mapSlice.actions;
 export default mapSlice.reducer;


### PR DESCRIPTION
# PR 제목
[Feat] 지도 컴포넌트에서 사용자 위치 처리 기능 구현
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 지도 컴포넌트에서 사용자 위치 정보 사용하기 위해 geolocation 으로 위치정보 받아옴

## 관련 이슈
- Close #67 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/67-map-user-geolocation`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- header 영역에서 현 위치 버튼 클릭시 유저 정보 받아와서 전역 상태 및 localStorage에 저장
- 바로 사용할때는 전역 상태값에서 위치 정보 사용
- 새로고침 하거나 다시 돌아온 경우는 localStorage에서 받아와서 전역 상태에 저장 후 사용
- slice에 유저 위치 정보 관련 내용 추가
- container 위치정보 기반 지도 리 렌더링 구현

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

https://github.com/user-attachments/assets/b1731351-6eba-4103-a920-933f06f584b0



## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)