### PR TITLE
Feat/63 회원가입 유효성 검사 로직 추가 + 완료 모달

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next": "16.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.66.0",
         "react-kakao-maps-sdk": "^1.2.0",
         "react-redux": "^9.2.0",
         "tailwind-merge": "^3.3.1",
@@ -8601,6 +8602,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.66.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
+      "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -2043,6 +2044,60 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -2228,6 +2283,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next": "16.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.66.0",
     "react-kakao-maps-sdk": "^1.2.0",
     "react-redux": "^9.2.0",
     "tailwind-merge": "^3.3.1",

--- a/src/components/common/modal/CommonModal.tsx
+++ b/src/components/common/modal/CommonModal.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import * as React from "react";
+
+type Variant = "default" | "success" | "error";
+
+export type ConfirmModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  onConfirm?: () => void;
+  variant?: Variant; // 라인/배경 토큰
+  // 필요 시 크기 조절
+  maxWidthPx?: number; // 기본 640
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/features/signup/singupform.tsx
+++ b/src/features/signup/singupform.tsx
@@ -1,10 +1,75 @@
+"use client";
+
 import Button from "@/components/common/button/Button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-
+import { SignupFormValues } from "@/types/singup";
+import { useForm } from "react-hook-form";
 export default function SignupForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+    watch,
+    setValue,
+  } = useForm<SignupFormValues>({
+    mode: "onBlur",
+    defaultValues: {
+      petDog: false,
+      petCat: false,
+      gender: undefined,
+      userName: "",
+      nickname: "",
+      email: "",
+      verificationCode: "",
+      password: "",
+      passwordConfirm: "",
+      agreeTerms: false,
+      agreePrivacy: false,
+      agreeMarketing: false,
+    },
+  });
+  {
+    /*제출*/
+  }
+  const onSubmit = (values: SignupFormValues) => {
+    if (values.password !== values.passwordConfirm) {
+      // 교차검증은 rules에도 있지만, 리마인드용으로 안전하게 한 번 더 체크해도 OK
+      return alert("비밀번호가 일치하지 않습니다.");
+    }
+    const pets: Array<"dog" | "cat"> = [];
+    if (values.petDog) pets.push("dog");
+    if (values.petCat) pets.push("cat");
+
+    const payload = {
+      gender: values.gender === "male" ? "male" : "female",
+      userName: values.userName.trim(),
+      nickname: values.nickname.trim(),
+      email: values.email.trim(),
+      pets,
+      havePet: pets.length ? "yes" : "no",
+      password: "*".repeat(values.password.length),
+      marketingOptIn: values.agreeMarketing,
+      agreed: { terms: values.agreeTerms, privacy: values.agreePrivacy },
+    };
+
+    console.log("payload", payload);
+    alert("유효성 통과! (콘솔 확인)");
+  };
+  // “전체 동의” 토글
+  const agreeTerms = watch("agreeTerms");
+  const agreePrivacy = watch("agreePrivacy");
+  const agreeMarketing = watch("agreeMarketing");
+  const allAgreed = agreeTerms && agreePrivacy && agreeMarketing;
+  const toggleAll = (checked: boolean) => {
+    setValue("agreeTerms", checked, { shouldValidate: true });
+    setValue("agreePrivacy", checked, { shouldValidate: true });
+    setValue("agreeMarketing", checked, { shouldValidate: true });
+  };
+
   return (
-    <section className="mx-auto w-full max-w-wrapper rounded-[28px] bg-background-100">
+    <section className="bg-background-100 mx-auto w-full max-w-wrapper rounded-[28px]">
       <div className="mx-auto flex max-w-[620px] flex-col items-center py-20">
         {/* 타이틀 */}
         <div className="mb-8 flex items-baseline gap-[12px]">
@@ -13,7 +78,7 @@ export default function SignupForm() {
         </div>
 
         {/* 폼 (스타일 전용) */}
-        <form className="w-full space-y-[12px]">
+        <form onSubmit={handleSubmit(onSubmit)} className="w-full space-y-[12px]">
           {/* 안내 문구 */}
           <div className="mb-[15px] w-full text-[13px] text-gray-100">
             <p className="text-[17px] font-semibold text-gray-900">반려동물 유무</p>
@@ -24,34 +89,30 @@ export default function SignupForm() {
           <div className="flex items-center gap-[12px]">
             {/* 강아지 */}
             <div>
-              <input 
-              id="pet-dog" 
-              name="pet_dog" 
-              type="checkbox" 
-              className="peer sr-only" />
+              <input
+                id="pet-dog"
+                type="checkbox"
+                className="peer sr-only"
+                {...register("petDog")}
+              />
               <Label
                 htmlFor="pet-dog"
-                className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900
-                          peer-checked:bg-orange-300 peer-checked:border-line-strong peer-checked:text-gray-50
-                          hover:bg-orange-300 hover:text-gray-50
-                          peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
+                className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900 hover:bg-orange-300 hover:text-gray-50 peer-checked:border-line-strong peer-checked:bg-orange-300 peer-checked:text-gray-50 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
               >
                 강아지
               </Label>
             </div>
             {/* 고양이 */}
             <div>
-              <input 
-              id="pet-cat" 
-              name="pet_cat" 
-              type="checkbox" 
-              className="peer sr-only" />
+              <input
+                id="pet-cat"
+                type="checkbox"
+                className="peer sr-only"
+                {...register("petCat")}
+              />
               <Label
                 htmlFor="pet-cat"
-                className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900
-                          peer-checked:bg-orange-300 peer-checked:border-line-strong peer-checked:text-gray-50
-                          hover:bg-orange-300 hover:text-gray-50
-                          peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
+                className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900 hover:bg-orange-300 hover:text-gray-50 peer-checked:border-line-strong peer-checked:bg-orange-300 peer-checked:text-gray-50 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
               >
                 고양이
               </Label>
@@ -69,35 +130,32 @@ export default function SignupForm() {
                 <input
                   id="male"
                   type="radio"
-                  name="gender"
-                  value="남자"
+                  value="male"
                   required
                   className="peer sr-only"
+                  {...register("gender", { required: "성별을 선택하세요." })}
                 />
                 <Label
                   htmlFor="male"
-                  className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900
-                            peer-checked:bg-orange-300 peer-checked:border-line-strong
-                            hover:bg-orange-300 hover:text-gray-50
-                            peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200">
-                              남자
+                  className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900 hover:bg-orange-300 hover:text-gray-50 peer-checked:border-line-strong peer-checked:bg-orange-300 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
+                >
+                  남자
                 </Label>
               </div>
               <div>
-                <input 
-                id="female" 
-                type="radio" 
-                name="gender" 
-                value="여자" 
-                className="peer sr-only" 
-                required/>
+                <input
+                  id="female"
+                  type="radio"
+                  value="female"
+                  className="peer sr-only"
+                  required
+                  {...register("gender", { required: "성별을 선택하세요." })}
+                />
                 <Label
                   htmlFor="female"
-                  className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900
-                            peer-checked:bg-orange-300 peer-checked:border-line-strong
-                            hover:bg-orange-300 hover:text-gray-50
-                            peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200">
-                              여자
+                  className="cursor-pointer rounded-full border border-line-strong px-[16px] py-[8px] text-[14px] text-gray-900 hover:bg-orange-300 hover:text-gray-50 peer-checked:border-line-strong peer-checked:bg-orange-300 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200"
+                >
+                  여자
                 </Label>
               </div>
             </div>
@@ -105,12 +163,33 @@ export default function SignupForm() {
 
           {/* 이름 */}
           <div>
-            <Input placeholder="[필수] 성명을 입력해 주세요" />
+            <Input
+              placeholder="[필수] 성명을 입력해 주세요"
+              {...register("userName", {
+                required: "성명을 입력하세요.",
+                minLength: { value: 2, message: "2자 이상" },
+              })}
+            />
+            {errors.userName && (
+              <p className="mt-1 text-[12px] text-red-500">{errors.userName.message}</p>
+            )}
           </div>
 
           {/* 닉네임 + 중복검사 */}
           <div className="grid grid-cols-[1fr_auto] items-center gap-[12px]">
-            <Input placeholder="[필수] 닉네임을 입력해 주세요" />
+            <div>
+              <Input
+                placeholder="[필수] 닉네임을 입력해 주세요"
+                {...register("nickname", {
+                  required: "닉네임을 입력하세요.",
+                  minLength: { value: 2, message: "2자 이상" },
+                  maxLength: { value: 20, message: "20자 이하" },
+                })}
+              />
+              {errors.nickname && (
+                <p className="mt-1 text-[12px] text-red-500">{errors.nickname.message}</p>
+              )}
+            </div>
             <Button className="rounded-full border-line-strong px-[12px] text-[12px] transition hover:bg-orange-300">
               중복검사
             </Button>
@@ -118,7 +197,22 @@ export default function SignupForm() {
 
           {/* 이메일 + 인증하기 */}
           <div className="grid grid-cols-[1fr_auto] items-center gap-[12px]">
-            <Input type="email" placeholder="[필수] 이메일을 입력해 주세요" />
+            <div>
+              <Input
+                type="email"
+                placeholder="[필수] 이메일을 입력해 주세요"
+                {...register("email", {
+                  required: "이메일을 입력하세요.",
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: "이메일 형식이 아닙니다.",
+                  },
+                })}
+              />
+              {errors.email && (
+                <p className="mt-1 text-[12px] text-red-500">{errors.email.message}</p>
+              )}
+            </div>
             <Button className="rounded-full border-line-strong px-[12px] text-[12px] transition hover:bg-orange-300">
               인증하기
             </Button>
@@ -126,26 +220,64 @@ export default function SignupForm() {
 
           {/* 인증번호 */}
           <div>
-            <Input placeholder="인증번호 입력" />
+            <Input
+              placeholder="인증번호 입력"
+              {...register("verificationCode", {
+                validate: (v) => !v || /^\d{6}$/.test(v) || "6자리 숫자",
+              })}
+            />
+            {errors.verificationCode && (
+              <p className="mt-1 text-[12px] text-red-500">{errors.verificationCode.message}</p>
+            )}
           </div>
 
           {/* 비밀번호 */}
           <div className="space-y-[4px]">
-            <Input type="password" placeholder="[필수] 비밀번호를 입력해 주세요" />
-            <p className="text-[12px] text-gray-300">· 비밀번호는 8자 이상/대소문자 혼합이어야 합니다.</p>
+            <Input
+              type="password"
+              placeholder="[필수] 비밀번호를 입력해 주세요"
+              {...register("password", {
+                required: "비밀번호를 입력하세요.",
+                pattern: {
+                  value: /^(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
+                  message: "8자 이상이며 대소문자를 혼합해야 합니다.",
+                },
+              })}
+            />
+            <p className="text-[12px] text-gray-300">
+              · 비밀번호는 8자 이상/대소문자 혼합이어야 합니다.
+            </p>
+            {errors.password && (
+              <p className="text-[12px] text-red-500">{errors.password.message}</p>
+            )}
           </div>
 
           {/* 비밀번호 확인 */}
           <div className="space-y-[4px]">
-            <Input type="password" placeholder="[필수] 비밀번호를 확인해 주세요" />
+            <Input
+              type="password"
+              placeholder="[필수] 비밀번호를 확인해 주세요"
+              {...register("passwordConfirm", {
+                required: "비밀번호를 다시 입력하세요.",
+                validate: (v) => v === getValues("password") || "비밀번호가 일치하지 않습니다.",
+              })}
+            />
             <p className="text-[12px] text-gray-300">· 위 비밀번호와 동일하게 작성해주세요.</p>
+            {errors.passwordConfirm && (
+              <p className="text-[12px] text-red-500">{errors.passwordConfirm.message}</p>
+            )}
           </div>
 
           {/* 개인정보 동의 */}
           <section className="mt-[24px] w-full rounded-[16px] border border-line-light bg-white p-[20px]">
             <div className="mb-[12px] flex items-center justify-between">
               <label className="flex items-center gap-[8px] text-[14px] font-semibold text-gray-900">
-                <input type="checkbox" className="h-[16px] w-[16px] accent-orange-300" />
+                <input
+                  type="checkbox"
+                  className="h-[16px] w-[16px] accent-orange-300"
+                  checked={allAgreed}
+                  onChange={(e) => toggleAll(e.currentTarget.checked)}
+                />
                 전체 동의
               </label>
               <span className="text-[12px] text-gray-400">선택 포함</span>
@@ -156,7 +288,11 @@ export default function SignupForm() {
             <ul className="flex flex-col gap-[12px]">
               <li className="flex items-start justify-between gap-[12px]">
                 <label className="flex flex-1 items-start gap-[8px] text-[14px] text-gray-900">
-                  <input type="checkbox" className="mt-[3px] h-[16px] w-[16px] accent-orange-300" />
+                  <input
+                    type="checkbox"
+                    className="mt-[3px] h-[16px] w-[16px] accent-orange-300"
+                    {...register("agreeTerms", { required: "이용약관 동의가 필요합니다." })}
+                  />
                   <span className="leading-[22px]">
                     이용약관 동의 <span className="text-warning">*</span>
                   </span>
@@ -168,7 +304,13 @@ export default function SignupForm() {
 
               <li className="flex items-start justify-between gap-[12px]">
                 <label className="flex flex-1 items-start gap-[8px] text-[14px] text-gray-900">
-                  <input type="checkbox" className="mt-[3px] h-[16px] w-[16px] accent-orange-300" />
+                  <input
+                    type="checkbox"
+                    className="mt-[3px] h-[16px] w-[16px] accent-orange-300"
+                    {...register("agreePrivacy", {
+                      required: "개인정보 수집·이용 동의가 필요합니다.",
+                    })}
+                  />
                   <span className="leading-[22px]">
                     개인정보 수집 및 이용 동의 <span className="text-warning">*</span>
                   </span>
@@ -180,7 +322,11 @@ export default function SignupForm() {
 
               <li className="flex items-start justify-between gap-[12px]">
                 <label className="flex flex-1 items-start gap-[8px] text-[14px] text-gray-900">
-                  <input type="checkbox" className="mt-[3px] h-[16px] w-[16px] accent-orange-300" />
+                  <input
+                    type="checkbox"
+                    className="mt-[3px] h-[16px] w-[16px] accent-orange-300"
+                    {...register("agreeMarketing")}
+                  />
                   <span className="leading-[22px]">마케팅 정보 수신 동의 (선택)</span>
                 </label>
                 <Button className="shrink-0 rounded-full border border-line-strong px-[12px] py-[6px] text-[12px] text-gray-900 transition hover:bg-orange-300">
@@ -192,7 +338,12 @@ export default function SignupForm() {
 
           {/* 제출 버튼 */}
           <div className="pt-[8px] text-center">
-            <Button className="inline-block rounded-full border border-line-strong px-[32px] py-[8px] text-sm font-semibold text-gray-900 transition hover:bg-orange-300 active:scale-[0.99]">회원가입</Button>
+            <Button
+              type="submit"
+              className="inline-block rounded-full border border-line-strong px-[32px] py-[8px] text-sm font-semibold text-gray-900 transition hover:bg-orange-300 active:scale-[0.99]"
+            >
+              회원가입
+            </Button>
           </div>
         </form>
       </div>

--- a/src/features/signup/singupform.tsx
+++ b/src/features/signup/singupform.tsx
@@ -5,7 +5,19 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SignupFormValues } from "@/types/singup";
 import { useForm } from "react-hook-form";
+import { useState } from "react";
+import {
+  DialogHeader,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
 export default function SignupForm() {
+  // 모달 상태
+  const [modalOpen, setModalOpen] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -34,10 +46,6 @@ export default function SignupForm() {
     /*제출*/
   }
   const onSubmit = (values: SignupFormValues) => {
-    if (values.password !== values.passwordConfirm) {
-      // 교차검증은 rules에도 있지만, 리마인드용으로 안전하게 한 번 더 체크해도 OK
-      return alert("비밀번호가 일치하지 않습니다.");
-    }
     const pets: Array<"dog" | "cat"> = [];
     if (values.petDog) pets.push("dog");
     if (values.petCat) pets.push("cat");
@@ -55,7 +63,7 @@ export default function SignupForm() {
     };
 
     console.log("payload", payload);
-    alert("유효성 통과! (콘솔 확인)");
+    setModalOpen(true); // 회원가입 버튼 클릭 시 환영 모달도 오픈
   };
   // “전체 동의” 토글
   const agreeTerms = watch("agreeTerms");
@@ -346,6 +354,29 @@ export default function SignupForm() {
             </Button>
           </div>
         </form>
+        <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>🎉 회원가입 완료</DialogTitle>
+              <DialogDescription>
+                {watch("userName")}님의 가입이 성공적으로 처리되었습니다!
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="mt-4 text-gray-900">
+              <p>로그인 페이지로 이동하시겠습니까?</p>
+            </div>
+
+            <div className="mt-4 flex justify-end">
+              <button
+                onClick={() => setModalOpen(false)}
+                className="rounded bg-green-500 p-2 text-white"
+              >
+                확인
+              </button>
+            </div>
+          </DialogContent>
+        </Dialog>
       </div>
     </section>
   );

--- a/src/types/singup.ts
+++ b/src/types/singup.ts
@@ -1,0 +1,22 @@
+export type Gender = "male" | "female";
+export type PetType = "dog" | "cat";
+
+export type SignupFormValues = {
+  // 반려동물: 둘 다 체크 가능, 둘 다 false면 '없음'
+  petDog: boolean;
+  petCat: boolean;
+
+  gender: "male" | "female" | undefined;
+  userName: string;
+  nickname: string;
+
+  email: string;
+  verificationCode?: string; // 6자리 (선택)
+  password: string;
+  passwordConfirm: string;
+
+  // 약관
+  agreeTerms: boolean; // 필수
+  agreePrivacy: boolean; // 필수
+  agreeMarketing: boolean; // 선택
+};


### PR DESCRIPTION
# PR 제목
[Feat] 회원가입 유효성 검사 로직 추가 + 완료 모달
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 회원가입 폼에 입력하는 필수 양식들 유효성 검사  

## 관련 이슈
- Close #63 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: feat/63-signupForm-validation
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 회원가입에서 받는 필수 양식들에 유효성 검사 추가
- 무사히 제출 완료될 시 완료 모달 추가

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)