### PR TITLE
[Feat] SSR 토큰 재발급 & 상태 동기화

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,11 @@
 import "./globals.css";
+import { cookies, headers } from "next/headers";
 
 import Header from "@/components/layout/Header";
 import ConfirmProvider from "@/providers/ConfirmProvider";
 import MSWProvider from "@/providers/MSWProvider";
 import QueryProvider from "@/providers/QueryProvider";
+import TokenHydrator from "@/providers/TokenHydrator";
 import ReduxProvider from "@/shared/store/ReduxProvider";
 
 import type { Metadata } from "next";
@@ -26,17 +28,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const headerList = await headers();
+  const cookieStore = await cookies();
+  const refreshedAccess = headerList.get("x-withpet-access-token");
+  const cookieAccess = cookieStore.get("access_token")?.value ?? null;
+  const accessToken = refreshedAccess ?? cookieAccess ?? null;
+
   return (
     <html lang="ko">
       <body className="flex min-h-screen flex-col bg-background text-gray-100">
         <QueryProvider>
           <ConfirmProvider>
             <ReduxProvider>
+              <TokenHydrator accessToken={accessToken} />
               <MSWProvider>
                 <Header />
                 <main className="mx-auto w-full max-w-layout flex-1">{children}</main>

--- a/src/features/login/api/loginApi.ts
+++ b/src/features/login/api/loginApi.ts
@@ -1,4 +1,4 @@
-import { backendClient, type BackendError } from "@/shared/api/backendClient";
+import { backendClient, type BackendError } from "@/shared/api/clientFeacher";
 import type { LoginErrorResponse, LoginRequestPayload, LoginSuccessResponse } from "@/types/login";
 
 export interface LoginResult {

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import Button from "@/components/common/button/Button";
-import { useConfirm } from "@/providers/ConfirmProvider";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useConfirm } from "@/providers/ConfirmProvider";
 import { isLoginErrorResponse, isLoginSuccessResponse } from "@/types/login";
 
 import { useLogin } from "../hooks/useLogin";

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -40,19 +40,17 @@ export default function LoginForm() {
     try {
       const result = await login({ email, password });
 
-      if (result.status >= 200 && result.status < 300) {
-        if (isLoginSuccessResponse(result.body) && result.body.message) {
-          const accepted = await confirm({
-            title: "환영합니다",
-            description: result.body.message,
-            confirmText: "확인",
-            cancelText: "닫기",
-          });
-          // 로그인 하면 홈으로 이동
-          // todo: 모달 버튼 클릭시 이동하게 변경
-          if (accepted) {
-            router.push("/");
-          }
+      if (result.status >= 200 && result.status < 300 && isLoginSuccessResponse(result.body)) {
+        const accepted = await confirm({
+          title: "환영합니다",
+          description: "로그인에 성공했어요!",
+          confirmText: "확인",
+          cancelText: "닫기",
+        });
+        // 로그인 하면 홈으로 이동
+        // todo: 모달 버튼 클릭시 이동하게 변경
+        if (accepted) {
+          router.push("/");
         }
         return;
       }

--- a/src/features/map/api/mapApi.ts
+++ b/src/features/map/api/mapApi.ts
@@ -1,4 +1,4 @@
-import { backendClient } from "@/shared/api/backendClient";
+import { backendClient } from "@/shared/api/clientFeacher";
 import { apiClient } from "@/shared/api/client";
 import type {
   CategoryResponse,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const BACKEND_BASE_URL =
+  process.env.NEXT_PUBLIC_BACKEND_API_URL?.replace(/\/$/, "") ?? "https://oz-withpet.kro.kr";
+
+const ACCESS_COOKIE = "access_token";
+const REFRESH_COOKIE = "refresh_token";
+
+const REFRESH_ENDPOINT = "/auth/token/refresh";
+
+const isTokenExpired = (token?: string | null) => {
+  if (!token) return true;
+  try {
+    const [, payload] = token.split(".");
+    if (!payload) return true;
+
+    const decoded = JSON.parse(Buffer.from(payload, "base64").toString());
+    if (!decoded?.exp) return false;
+    const expiresAt = decoded.exp * 1000;
+
+    return Date.now() >= expiresAt - 1000;
+  } catch {
+    return true;
+  }
+};
+
+const requestRefresh = async (refreshToken: string) => {
+  const response = await fetch(`${BACKEND_BASE_URL}${REFRESH_ENDPOINT}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("refresh failed");
+  }
+
+  const data = (await response.json()) as { access?: string };
+  if (!data.access) {
+    throw new Error("no access token");
+  }
+  return data.access;
+};
+
+export async function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value ?? null;
+  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value ?? null;
+
+  // refresh 토큰이 없으면 검사할 필요도 없으므로 그대로 통과시킨다.
+  if (!refreshToken) {
+    return NextResponse.next();
+  }
+
+  // access 토큰이 존재하고 아직 유효하면 그대로 다음 단계 진행
+  if (!isTokenExpired(accessToken)) {
+    return NextResponse.next();
+  }
+
+  try {
+    const newAccessToken = await requestRefresh(refreshToken);
+    const requestHeaders = new Headers(request.headers);
+
+    // x-withpet-access-token: SSR 레이아웃이 새 토큰을 읽어 Redux에 넣을 수 있게 하는 custom 헤더
+    requestHeaders.set("x-withpet-access-token", newAccessToken);
+
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+
+    // 새 access 토큰을 httpOnly 쿠키에 다시 심어서 다음 SSR 요청에서도 사용 가능하게 한다.
+    response.cookies.set({
+      name: ACCESS_COOKIE,
+      value: newAccessToken,
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+    });
+
+    return response;
+  } catch (error) {
+    console.warn("access refresh failed", error);
+    const response = NextResponse.next();
+    response.cookies.delete(ACCESS_COOKIE);
+    response.cookies.delete(REFRESH_COOKIE);
+    return response;
+  }
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/src/providers/TokenHydrator.tsx
+++ b/src/providers/TokenHydrator.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useDispatch } from "react-redux";
+
+import type { AppDispatch } from "@/shared/store";
+import { clearTokens, setTokens } from "@/shared/store/authSlice";
+
+interface TokenHydratorProps {
+  accessToken: string | null;
+}
+
+/**
+ * @@토큰동기화
+ * @@설명: 서버 미들웨어에서 갱신한 access 토큰을 클라이언트 Redux 상태와 맞춰준다.
+ */
+export default function TokenHydrator({ accessToken }: TokenHydratorProps) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    // 서버에서 새 access 토큰을 받아왔다면 Redux에 저장해서 CSR fetcher가 바로 사용할 수 있게 한다.
+    if (accessToken) {
+      dispatch(
+        setTokens({
+          accessToken,
+          tokenType: "Bearer",
+          expiresIn: 0,
+        }),
+      );
+      return;
+    }
+
+    // 토큰이 없으면 로그아웃 상태로 전환해서 보호된 페이지 접근 시 재로그인을 유도한다.
+    dispatch(clearTokens());
+  }, [accessToken, dispatch]);
+
+  return null;
+}

--- a/src/shared/api/clientFeacher.ts
+++ b/src/shared/api/clientFeacher.ts
@@ -20,7 +20,7 @@ export interface BackendError extends Error {
 }
 
 /**
- * @@백엔드클라이언트
+ * @@ 클라이언트용 fetch 래퍼
  * 경로만 넘기면 헤더, 인증, 오류 파싱까지 한 번에 처리되는 fetch 래퍼
  */
 export async function backendClient<T>(

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -5,8 +5,6 @@ export type LoginRequestPayload = {
 
 export type LoginSuccessResponse = {
   access: string;
-  refresh: string;
-  message?: string;
 };
 
 export type LoginErrorResponse = {
@@ -15,7 +13,7 @@ export type LoginErrorResponse = {
 };
 
 export const isLoginSuccessResponse = (body: unknown): body is LoginSuccessResponse =>
-  Boolean(body && typeof body === "object" && "access" in body && "refresh" in body);
+  Boolean(body && typeof body === "object" && "access" in body);
 
 export const isLoginErrorResponse = (body: unknown): body is LoginErrorResponse =>
   Boolean(body && typeof body === "object" && ("detail" in body || "message" in body));


### PR DESCRIPTION
# PR 제목
[Feat] SSR 토큰 재발급 & 상태 동기화
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 미들웨어에서 access 토큰 만료 여부를 검사하고, refresh 토큰으로 자동 재발급해 쿠키/헤더에 다시 세팅
- 레이아웃에 TokenHydrator를 도입해 SSR에서 받은 토큰을 Redux 상태로 최신 토큰 저장하도록 구현

## 관련 이슈
- Close #77 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/77-refresh-middleware`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- Next.js 미들웨어에서 /auth/token/refresh 호출 후 토큰 쿠키/헤더 갱신
- TokenHydrator 추가 및 레이아웃에서 헤더·쿠키 기반 Redux 동기화

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)