### PR TITLE
[Feat] 미들웨어 토큰 재발급 로직 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 
 import Header from "@/components/layout/Header";
 import ConfirmProvider from "@/providers/ConfirmProvider";
@@ -33,11 +33,8 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const headerList = await headers();
   const cookieStore = await cookies();
-  const refreshedAccess = headerList.get("x-withpet-access-token");
-  const cookieAccess = cookieStore.get("access_token")?.value ?? null;
-  const accessToken = refreshedAccess ?? cookieAccess ?? null;
+  const accessToken = cookieStore.get("access_token")?.value ?? null;
 
   return (
     <html lang="ko">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,26 +2,15 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const BACKEND_BASE_URL =
   process.env.NEXT_PUBLIC_BACKEND_API_URL?.replace(/\/$/, "") ?? "https://oz-withpet.kro.kr";
-
 const ACCESS_COOKIE = "access_token";
 const REFRESH_COOKIE = "refresh_token";
-
 const REFRESH_ENDPOINT = "/auth/token/refresh";
+const LOGIN_PATH = "/login";
+const PUBLIC_PATHS = ["/login", "/signup"];
 
-const isTokenExpired = (token?: string | null) => {
-  if (!token) return true;
-  try {
-    const [, payload] = token.split(".");
-    if (!payload) return true;
-
-    const decoded = JSON.parse(Buffer.from(payload, "base64").toString());
-    if (!decoded?.exp) return false;
-    const expiresAt = decoded.exp * 1000;
-
-    return Date.now() >= expiresAt - 1000;
-  } catch {
-    return true;
-  }
+const isPublicPath = (pathname: string) => {
+  if (pathname === "/") return true;
+  return PUBLIC_PATHS.some((path) => pathname.startsWith(path));
 };
 
 const requestRefresh = async (refreshToken: string) => {
@@ -43,32 +32,29 @@ const requestRefresh = async (refreshToken: string) => {
   return data.access;
 };
 
-export async function middleware(request: NextRequest) {
-  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value ?? null;
-  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value ?? null;
+const redirectToLogin = (request: NextRequest) =>
+  NextResponse.redirect(new URL(LOGIN_PATH, request.url));
 
-  // refresh 토큰이 없으면 검사할 필요도 없으므로 그대로 통과시킨다.
-  if (!refreshToken) {
+export async function middleware(request: NextRequest) {
+  if (isPublicPath(request.nextUrl.pathname)) {
     return NextResponse.next();
   }
 
-  // access 토큰이 존재하고 아직 유효하면 그대로 다음 단계 진행
-  if (!isTokenExpired(accessToken)) {
+  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value ?? null;
+  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value ?? null;
+
+  if (accessToken) {
     return NextResponse.next();
+  }
+
+  if (!refreshToken) {
+    return redirectToLogin(request);
   }
 
   try {
     const newAccessToken = await requestRefresh(refreshToken);
-    const requestHeaders = new Headers(request.headers);
+    const response = NextResponse.next();
 
-    // x-withpet-access-token: SSR 레이아웃이 새 토큰을 읽어 Redux에 넣을 수 있게 하는 custom 헤더
-    requestHeaders.set("x-withpet-access-token", newAccessToken);
-
-    const response = NextResponse.next({
-      request: { headers: requestHeaders },
-    });
-
-    // 새 access 토큰을 httpOnly 쿠키에 다시 심어서 다음 SSR 요청에서도 사용 가능하게 한다.
     response.cookies.set({
       name: ACCESS_COOKIE,
       value: newAccessToken,
@@ -81,7 +67,7 @@ export async function middleware(request: NextRequest) {
     return response;
   } catch (error) {
     console.warn("access refresh failed", error);
-    const response = NextResponse.next();
+    const response = redirectToLogin(request);
     response.cookies.delete(ACCESS_COOKIE);
     response.cookies.delete(REFRESH_COOKIE);
     return response;


### PR DESCRIPTION
# PR 제목
[Feat] 미들웨어 토큰 재발급 로직 변경
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 토큰 재발급 로직 변경 및 리다이렉트 추가

## 관련 이슈
- Close #85 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `feat/85-middleware-logic-edit`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 미들웨어에서 토큰 갱신 전 유효성 검증 단계 추가해서 리소스 절약
- 토큰 필요없는 페이지 관리 및 return 하도록 로직 변경
- 토큰 갱신 error시 login 페이지로 리다이렉트

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)