### PR TITLE
Feat: 마이페이지 프로필 조회 API 연동 및 React Query 적용

### DIFF
--- a/src/features/mypage/api/mypageApi.ts
+++ b/src/features/mypage/api/mypageApi.ts
@@ -19,6 +19,10 @@ export const getMyProfile = () => {
     auth: "private",
   });
 };
+export const getMyProfileData = async () => {
+  const res = await getMyProfile();
+  return res.data;
+};
 
 // 2) 내 프로필 수정 PATCH /mypage/profile
 export const updateMyProfile = (payload: MyProfileUpdateRequest) => {

--- a/src/features/mypage/profile/ui/MypageProfileForm.tsx
+++ b/src/features/mypage/profile/ui/MypageProfileForm.tsx
@@ -1,37 +1,38 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
 import Link from "next/link";
 
 import { useDispatch } from "react-redux";
 
-import { getMyProfile, withdraw } from "@/features/mypage/api/mypageApi";
+import { withdraw } from "@/features/mypage/api/mypageApi";
 import { useConfirm } from "@/providers/ConfirmProvider";
 import { clearTokens } from "@/shared/store/authSlice";
-import { MyProfileData } from "@/types/mypage";
-export default function MypageProfileForm() {
-  const [profile, setProfile] = useState<MyProfileData | null>(null);
-  const [loading, setLoading] = useState(true);
 
+import { useMyProfileQuery } from "./useMyProfileQuery";
+
+export default function MypageProfileForm() {
   const confirm = useConfirm();
   const dispatch = useDispatch();
 
-  //  내 프로필 조회
-  useEffect(() => {
-    const fetchProfile = async () => {
-      try {
-        const res = await getMyProfile();
-        setProfile(res.data);
-      } catch (error) {
-        console.error("[GET MY PROFILE ERROR]", error);
-      } finally {
-        setLoading(false);
-      }
-    };
+  const { data, isLoading, isError } = useMyProfileQuery();
 
-    fetchProfile();
-  }, []);
+  console.log("MypageProfileForm", data);
+
+  if (isLoading) {
+    return (
+      <div className="flex w-wrapper items-center justify-center p-40 text-gray-900">
+        프로필 불러오는 중...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex w-wrapper items-center justify-center p-40 text-gray-900">
+        프로필 정보를 불러오지 못했습니다.
+      </div>
+    );
+  }
 
   //  회원탈퇴
   const onDelete = async () => {
@@ -72,40 +73,24 @@ export default function MypageProfileForm() {
     }
   };
 
-  // 2) 로딩/에러 처리
-  if (loading) {
-    return (
-      <div className="flex w-wrapper items-center justify-center p-40 text-gray-900">
-        프로필 불러오는 중...
-      </div>
-    );
-  }
-
-  if (!profile) {
-    return (
-      <div className="flex w-wrapper items-center justify-center p-40 text-gray-900">
-        프로필 정보를 불러오지 못했습니다.
-      </div>
-    );
-  }
   // 3) 표시용 값 가공
-  const genderText = profile.gender === "male" ? "남자" : "여자";
+  const genderText = data?.gender === "male" ? "남자" : "여자";
   let petText = "없음";
-  if (profile.pet_type === "dog") petText = "강아지";
-  else if (profile.pet_type === "cat") petText = "고양이";
+  if (data?.pet_type === "dog") petText = "강아지";
+  else if (data?.pet_type === "cat") petText = "고양이";
 
   return (
     <div className="flex w-wrapper items-center justify-center bg-orange-100 p-40 text-gray-900">
       <div className="flex w-edit flex-col rounded-xl border border-gray-300 p-3">
         <div className="mb-9 flex w-full items-center justify-center p-3 text-2xl">
-          {profile.nickname}님 프로필
+          {data?.nickname || "nickname"}님 프로필
         </div>
 
         <div className="flex h-[285px] flex-col justify-between">
           <div className="flex items-center hover:cursor-default">
             이름:
             <div className="ml-2 rounded-full border-2 border-orange-300 bg-white px-5 py-1">
-              {profile.username}
+              {data?.username || "이름없음"}
             </div>
           </div>
 
@@ -119,14 +104,14 @@ export default function MypageProfileForm() {
           <div className="flex items-center hover:cursor-default">
             이메일:
             <div className="ml-2 rounded-full border-2 border-orange-300 bg-white px-5 py-1">
-              {profile.email}
+              {data?.email}
             </div>
           </div>
 
           <div className="flex items-center hover:cursor-default">
             닉네임:
             <div className="ml-2 rounded-full border-2 border-orange-300 bg-white px-5 py-1">
-              {profile.nickname}
+              {data?.nickname || "nickname"}
             </div>
           </div>
 

--- a/src/features/mypage/profile/ui/useMyProfileQuery.ts
+++ b/src/features/mypage/profile/ui/useMyProfileQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { MyProfileData } from "@/types/mypage";
+
+import { getMyProfileData } from "../../api/mypageApi";
+
+export function useMyProfileQuery() {
+  return useQuery<MyProfileData>({
+    queryKey: ["mypage", "profile"],
+    queryFn: getMyProfileData,
+    staleTime: 1000 * 10,
+  });
+}

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -19,6 +19,7 @@ export interface MyProfileData {
 }
 export interface MyProfileResponse {
   success: boolean;
+  message: string;
   data: MyProfileData;
 }
 


### PR DESCRIPTION
# PR 제목
Feat: 마이페이지 프로필 조회 API 연동 및 React Query 적용
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 마이페이지 프로필 화면에 실제 로그인한 사용자 정보를 조회하는 기능을 추가했습니다.
- 프로필 조회 로직을 도메인 함수 + React Query 훅으로 분리하여 재사용성과 가독성을 개선했습니다.

## 관련 이슈
- Close #110 

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `Feat/110-mypage-profile-query`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- `src/features/mypage/api/mypageApi.ts`
  - `getMyProfile` API 래퍼 추가 (`GET /mypage/profile`)
  - 응답에서 `data`만 반환하는 도메인 함수 `getMyProfileData` 추가

- `src/features/mypage/profile/ui/useMyProfileQuery.ts`
  - 마이페이지 프로필 조회용 React Query 훅 `useMyProfileQuery` 구현
  - `queryKey: ["mypage", "profile"]` 기반으로 캐싱 처리

- `src/features/mypage/profile/ui/MypageProfileForm.tsx`
  - 기존 `useEffect + useState` 기반 수동 fetch 로직 제거
  - `useMyProfileQuery`를 사용해 로딩/에러/데이터 상태 관리
  - `data` → `profile`로 변수명 명확히 변경 및 optional chaining 정리
  - 로딩/에러 UI 분기 추가

## 스크린샷/동영상(선택)
### 구현 전 (useEffect로 받은 데이터)
<img width="2560" height="1314" alt="스크린샷 2025-11-19 오후 9 38 41" src="https://github.com/user-attachments/assets/54e29f94-a53b-4ccf-82a4-67482cb9fa66" />

 ### 구현 후 (React Query으로 구현)
<img width="2560" height="1315" alt="스크린샷 2025-11-19 오후 9 38 29" src="https://github.com/user-attachments/assets/19b88721-41df-4c69-94fc-f5e7ada9b974" />


## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [ ] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [ ] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [ ] PR 대상: `dev`
- [ ] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [ ] 관련 이슈 링크 (예: `Close #5`)