### PR TITLE
[Fix] build.sh 수정

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
-cd ../
-mkdir output
-cp -R ./WithPet-FE/* ./output
-cp -R ./output ./WithPet-FE/
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$ROOT_DIR/output"
+
+echo "[build.sh] preparing clean output directory"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+echo "[build.sh] copying project files (excluding node_modules/.next/output/.git)"
+rsync -av --delete \\
+  --exclude '.git' \\
+  --exclude '.next' \\
+  --exclude 'node_modules' \\
+  --exclude 'output' \\
+  "$ROOT_DIR/" "$OUTPUT_DIR/"
+
+echo "[build.sh] output prepared at $OUTPUT_DIR"


### PR DESCRIPTION
# PR 제목
[Fix] build.sh 수정
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 변경된 depoly로 적용후 빌드시 필요없는 빌드파일이 전부 push 되는 에러발생

## 관련 이슈
- Close #122

## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `fix/120-build-fix`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 주요 변경점(화면/로직/폴더 구조)
- 의존성 추가/삭제(있다면)
- 환경 설정 변경 내용(있다면)

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)