### PR TITLE
[Style] global font import 변경 및 미사용 버튼 주석

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,10 +4,11 @@
 
 @font-face {
   font-family: "Pretendard Variable";
-  font-weight: 100 900;
   font-style: normal;
+  font-weight: 100 900;
   font-display: swap;
-  src: url("/fonts/PretendardVariable.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/woff2/PretendardVariable.woff2")
+    format("woff2");
 }
 
 :root {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import "./globals.css";
 import { cookies } from "next/headers";
 
 import Header from "@/components/layout/Header";
@@ -7,6 +6,7 @@ import MSWProvider from "@/providers/MSWProvider";
 import QueryProvider from "@/providers/QueryProvider";
 import TokenHydrator from "@/providers/TokenHydrator";
 import ReduxProvider from "@/shared/store/ReduxProvider";
+import "./globals.css";
 
 import type { Metadata } from "next";
 

--- a/src/components/common/comment/CommentForm.tsx
+++ b/src/components/common/comment/CommentForm.tsx
@@ -36,12 +36,12 @@ export default function CommentForm({ items }: Props) {
             </div>
             <div className="py-3">{el.content}</div>
             <div className="flex w-main justify-end">
-              <div className="rounded-2xl border border-orange-300 px-3 py-1 text-xs hover:cursor-pointer hover:bg-orange-300 hover:font-semibold hover:text-white">
+              {/* <div className="rounded-2xl border border-orange-300 px-3 py-1 text-xs hover:cursor-pointer hover:bg-orange-300 hover:font-semibold hover:text-white">
                 수정하기
               </div>
               <button className="ml-2 rounded-2xl border border-red-600 px-3 py-1 text-xs hover:cursor-pointer hover:bg-red-600 hover:font-semibold hover:text-white">
                 삭제하기
-              </button>
+              </button> */}
             </div>
           </div>
         ))


### PR DESCRIPTION
# PR 제목
[Style] global font import 변경 및 미사용 버튼 주석
> Type: Chore | Feat | Fix | Style | Docs | Refactor

## 개요
- 빌드 후 폰트 미 적용 이슈 발생

## 관련 이슈
- Close #134 
## 브랜치 정보 (규칙 확인)
- 현재 브랜치: `style/134-global-font`  
- 규칙: `type/{이슈번호-요약}` (예: `feat/3-common-modal`)  
- PR 대상 브랜치: `dev`

## 변경 사항
- 주요 변경점(화면/로직/폴더 구조)
- 의존성 추가/삭제(있다면)
- 환경 설정 변경 내용(있다면)

## 스크린샷/동영상(선택)
- 전/후 비교, 로딩/에러 화면 등 시각 자료가 있다면 첨부

## 테스트 노트 (※ 테스트 코드 미작성 프로젝트)
- 수동 테스트 시나리오 및 확인 포인트를 기록해주세요.
- 예: npm run dev 실행 시 정상 빌드 및 동작 여부 확인

## 체크리스트
- [x] 브랜치 네이밍: `type/{이슈번호-요약}` (예: `feat/5-cart-modal`)
- [x] 커밋 타입: Chore/Feat/Fix/Style/Docs/Refactor 중 사용
- [x] PR 대상: `dev`
- [x] ESLint / 타입 체크 통과 (`npm run lint`, `tsc --noEmit`)
- [x] 관련 이슈 링크 (예: `Close #5`)